### PR TITLE
build-dist.sh file screws up ability to commit dist folder

### DIFF
--- a/deployment/build-dist.sh
+++ b/deployment/build-dist.sh
@@ -19,8 +19,7 @@
 # Check to see if input has been provided:
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
     echo "Please provide the base source bucket name, trademark approved solution name and version where the lambda code will eventually reside."
-    echo "For example: ./build-dist.sh solutions web-client-for-aws-transfer-family v1.0.0
-"
+    echo "For example: ./build-dist.sh solutions web-client-for-aws-transfer-family v1.0.0"
     exit 1
 fi
 


### PR DESCRIPTION
* Because build-dist.sh file does not exclude the .git folder from being copied we end up with an extraneous .git folder in the dist folder which wreaks havoc with the local repository. 
* Also fixing up the help to mirror what is in the readme. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
