### PR TITLE
Fixed the dependency for Flask Version.

### DIFF
--- a/source/backend/requirements.txt
+++ b/source/backend/requirements.txt
@@ -1,4 +1,6 @@
-Flask==1.1.2
+Werkzeug==2.0.0
+jinja2==3.0.3
+Flask==2.1.0
 Flask-Cors==3.0.8
 Paramiko==2.7.1
 flask_jwt_extended==3.25.1


### PR DESCRIPTION
Fargate containers were failing with Jinja and Flask dependency.

*Issue #, if available:*
Front end issue is this: https://github.com/awslabs/web-client-for-aws-transfer-family/issues/11
in backend the fargate tasks do not start successfully and cause the error.

*Description of changes:*
Updated the dependencies for Python runtime


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
